### PR TITLE
Headless

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -64,7 +64,7 @@
             "no-new-wrappers": [2],
             "no-new": [2],
             "no-param-reassign": [1],
-            "no-process-env": [1],
+            "no-process-env": [0],
             "no-proto": [2],
             "no-redeclare": [1],
             "no-return-assign": [2],

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ main.js.map
 
 # Local tests
 test/set_creds.sh
+
+config.json

--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,3 @@ main.js.map
 
 # Local tests
 test/set_creds.sh
-
-config.json

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The database connector is in Alpha release and the Potly 2.0 web interface is cu
 
 #### Contact
 - Chris - chris@plot.ly
-- Alexandre - alexs@plot.ly
+- Alexandre - alexandres@plot.ly
 
 ## Development
 

--- a/app/components/Settings/Logger/Logger.react.js
+++ b/app/components/Settings/Logger/Logger.react.js
@@ -7,7 +7,7 @@ const Logger = props => {
     if (!props.logs || props.logs.length === 0) return null;
 
     const renderLogs = props.logs.map(log => (
-        <div>{log.timestamp} - {log.description}</div>
+        <div>{log.timestamp} - {log.logEntry}</div>
     ));
 
     const testClass = () => {

--- a/app/components/Settings/Logger/LoggerController.react.js
+++ b/app/components/Settings/Logger/LoggerController.react.js
@@ -22,7 +22,7 @@ export default class LoggerController extends Component {
             this.props.ipc.getIn(errorPath)) {
 
             this.state.logs.unshift({
-                description: nextProps.ipc.getIn(errorPath),
+                logEntry: nextProps.ipc.getIn(errorPath),
                 timestamp: nextProps.ipc.getIn(['error', 'timestamp'])
             });
 

--- a/args.js
+++ b/args.js
@@ -14,8 +14,8 @@ export const options = {
         acceptedValues: range(1, 10000)
     },
     logpath: {
-        defaultValue: './log.txt',
-        acceptedValues: 'path to logpath w/o quotes (ex: path/to/log.txt)'
+        defaultValue: './activity.log',
+        acceptedValues: 'path to logpath w/o quotes (ex: path/to/file.log)'
     },
     configpath: {
         defaultValue: './config.json',

--- a/args.js
+++ b/args.js
@@ -1,6 +1,6 @@
 import {contains, isEmpty, merge, mergeAll, range, split} from 'ramda';
 
-export const options = {
+const optionsBook = {
     headless: {
         defaultValue: false,
         acceptedValues: [false, true]
@@ -31,8 +31,8 @@ const optionsToCheck = ['headless', 'large', 'port'];
 
 // returns all the default values from options as a dict {key: default, ...}
 const defaultOptions = () => {
-    return mergeAll(Object.keys(options).map( (key) => {
-        return {[key]: options[key].defaultValue };
+    return mergeAll(Object.keys(optionsBook).map( (key) => {
+        return {[key]: optionsBook[key].defaultValue };
     }));
 };
 
@@ -54,10 +54,10 @@ function mergeArgs (args) {
 
     const wrongFormat = (arg) => arg.length !== 2;
 
-    const wrongArg = (arg) => !contains(arg[0], Object.keys(options));
+    const wrongArg = (arg) => !contains(arg[0], Object.keys(optionsBook));
 
     const wrongValue = (arg) => {
-        const acceptedValues = options[arg[0]].acceptedValues;
+        const acceptedValues = optionsBook[arg[0]].acceptedValues;
         if (contains(arg[0], optionsToCheck)) {
             return !contains(arg[1], acceptedValues);
         }
@@ -70,7 +70,7 @@ function mergeArgs (args) {
 
     const wrongArgError = (arg) => {
         return `Can\'t find \'${arg[0]}\' in the possible options...` +
-        `Here are the options: ${Object.keys(options)}`;
+        `Here are the options: ${Object.keys(optionsBook)}`;
     };
 
     const wrongValueError = (arg) => {
@@ -80,7 +80,7 @@ function mergeArgs (args) {
 
         return `Can\'t find \'${arg[1]}\' in the possible values for` +
         `\'${arg[0]}\'...` +
-        `Valid values for this key are: ${options[arg[0]].acceptedValues}`;
+        `Valid values for this key are: ${optionsBook[arg[0]].acceptedValues}`;
     };
 
     // args are expected to be in ['key=value', 'key1=value2' ...] format
@@ -102,7 +102,6 @@ function mergeArgs (args) {
         }
 
     } catch (error) {
-        console.error(`Error. Please try again... ${error}`);
         process.exit(-1);
 
     } finally {
@@ -115,4 +114,4 @@ const acceptedArgs = () => {
     return process.env.NODE_ENV === 'development' ? {} : process.argv.slice(2);
 };
 
-export const OPTIONS = mergeArgs(acceptedArgs());
+export const ARGS = mergeArgs(acceptedArgs());

--- a/args.js
+++ b/args.js
@@ -1,0 +1,118 @@
+import {contains, isEmpty, merge, mergeAll, range, split} from 'ramda';
+
+export const options = {
+    headless: {
+        defaultValue: false,
+        acceptedValues: [false, true]
+    },
+    large: {
+        defaultValue: true,
+        acceptedValues: [false, true]
+    },
+    port: {
+        defaultValue: 5000,
+        acceptedValues: range(1, 10000)
+    },
+    logpath: {
+        defaultValue: './log.txt',
+        acceptedValues: 'path to logpath w/o quotes (ex: path/to/log.txt)'
+    },
+    configpath: {
+        defaultValue: './config.json',
+        acceptedValues: 'path to config w/o quotes (ex: path/to/config.json)'
+    },
+    logdetail: {
+        defaultValue: 0,
+        acceptedValues: range(0, 4)
+    }
+};
+
+const optionsToCheck = ['headless', 'large', 'port'];
+
+// returns all the default values from options as a dict {key: default, ...}
+const defaultOptions = () => {
+    return mergeAll(Object.keys(options).map( (key) => {
+        return {[key]: options[key].defaultValue };
+    }));
+};
+
+function mergeArgs (args) {
+    const userOptions = {};
+
+    const parseArgValue = (arg) => {
+        switch (arg[0]) {
+            case 'headless':
+            case 'large':
+                return [arg[0], ((arg[1] === 'true') ? true : false)];
+            case 'port':
+            case 'logdetail':
+                return [arg[0], parseInt(arg[1], 10)];
+            default:
+                return arg;
+        }
+    };
+
+    const wrongFormat = (arg) => arg.length !== 2;
+
+    const wrongArg = (arg) => !contains(arg[0], Object.keys(options));
+
+    const wrongValue = (arg) => {
+        const acceptedValues = options[arg[0]].acceptedValues;
+        if (contains(arg[0], optionsToCheck)) {
+            return !contains(arg[1], acceptedValues);
+        }
+        return false;
+    };
+
+    const wrongFormatError = (arg) => {
+        return `Command Line argument \'${arg}]'' was not of key=value format`;
+    };
+
+    const wrongArgError = (arg) => {
+        return `Can\'t find \'${arg[0]}\' in the possible options...` +
+        `Here are the options: ${Object.keys(options)}`;
+    };
+
+    const wrongValueError = (arg) => {
+        if (arg[0] === 'port') {
+            return 'Port number must be an integer between 1 and 9999';
+        }
+
+        return `Can\'t find \'${arg[1]}\' in the possible values for` +
+        `\'${arg[0]}\'...` +
+        `Valid values for this key are: ${options[arg[0]].acceptedValues}`;
+    };
+
+    // args are expected to be in ['key=value', 'key1=value2' ...] format
+    try {
+        if (!isEmpty(args)) {
+            args.forEach( expression => {
+                const arg = split('=', expression);
+                const parsedArg = parseArgValue(arg);
+                if (wrongFormat(parsedArg)) {
+                    throw new Error(wrongFormatError(parsedArg));
+                } else if (wrongArg(parsedArg)) {
+                    throw new Error(wrongArgError(parsedArg));
+                } else if (wrongValue(parsedArg)) {
+                    throw new Error(wrongValueError(parsedArg));
+                } else {
+                    userOptions[parsedArg[0]] = parsedArg[1];
+                }
+            });
+        }
+
+    } catch (error) {
+        console.error(`Error. Please try again... ${error}`);
+        process.exit(-1);
+
+    } finally {
+        return merge(defaultOptions(), userOptions);
+    }
+}
+
+// if in development mode, just pass in an empty args object => defaults all
+const acceptedArgs = () => {
+    return process.env.NODE_ENV === 'development' ? {} : process.argv.slice(2);
+};
+
+export const OPTIONS = mergeArgs(acceptedArgs());

--- a/args.js
+++ b/args.js
@@ -21,8 +21,9 @@ const optionsBook = {
         defaultValue: './config.json',
         acceptedValues: 'path to config w/o quotes (ex: path/to/config.json)'
     },
+    // 0 for errors only, 1 adds warnings, 2 adds info
     logdetail: {
-        defaultValue: 0,
+        defaultValue: 1,
         acceptedValues: range(0, 4)
     }
 };

--- a/args.js
+++ b/args.js
@@ -37,6 +37,7 @@ const defaultOptions = () => {
     }));
 };
 
+// args are expected to be in ['key=value', 'key1=value2' ...] format
 function mergeArgs (args) {
     const userOptions = {};
 
@@ -84,9 +85,8 @@ function mergeArgs (args) {
         `Valid values for this key are: ${optionsBook[arg[0]].acceptedValues}`;
     };
 
-    // args are expected to be in ['key=value', 'key1=value2' ...] format
     try {
-        if (!isEmpty(args)) {
+        if (!isEmpty(args) && !contains('--test-type=webdriver', args)) {
             args.forEach( expression => {
                 const arg = split('=', expression);
                 const parsedArg = parseArgValue(arg);
@@ -101,18 +101,27 @@ function mergeArgs (args) {
                 }
             });
         }
-
     } catch (error) {
+        // keep this console log for the user running it from the CL
+        console.error(error);
         process.exit(-1);
-
-    } finally {
-        return merge(defaultOptions(), userOptions);
     }
+    return merge(defaultOptions(), userOptions);
 }
 
 // if in development mode, just pass in an empty args object => defaults all
 const acceptedArgs = () => {
-    return process.env.NODE_ENV === 'development' ? {} : process.argv.slice(2);
+
+    let argsToMerge = [];
+
+    if (process.env.NODE_ENV === 'development') {
+        argsToMerge = ['logdetail=2'];
+    } else if (!contains('./test/e2e.js', process.argv.slice(2))) {
+        argsToMerge = process.argv.slice(2);
+    }
+
+    return argsToMerge;
+
 };
 
 export const ARGS = mergeArgs(acceptedArgs());

--- a/config.json
+++ b/config.json
@@ -1,0 +1,9 @@
+{
+    "username": null,
+    "password": null,
+    "database": null,
+    "port": null,
+    "dialect": null,
+    "storage": null,
+    "host": null
+}

--- a/main.development.js
+++ b/main.development.js
@@ -47,9 +47,6 @@ app.on('ready', () => {
     function log(logEntry, code = 2) {
 
         // default log detail set to 1 (warn level) in ./args.js
-
-        console.log(code, logEntry);
-
         if (code <= OPTIONS.logdetail) {
             switch (code) {
                 case 0:

--- a/main.development.js
+++ b/main.development.js
@@ -60,6 +60,9 @@ app.on('ready', () => {
         server.get('/connect', serverMessageReceive(
             sequelizeManager, mainWindow.webContents)
         );
+        server.get('/login', serverMessageReceive(
+            sequelizeManager, mainWindow.webContents)
+        );
         server.get('/query', serverMessageReceive(
             sequelizeManager, mainWindow.webContents)
         );
@@ -70,6 +73,9 @@ app.on('ready', () => {
             sequelizeManager, mainWindow.webContents)
         );
         server.get('/v0/connect', serverMessageReceive(
+            sequelizeManager, mainWindow.webContents)
+        );
+        server.get('/v0/login', serverMessageReceive(
             sequelizeManager, mainWindow.webContents)
         );
         server.get('/v0/query', serverMessageReceive(

--- a/main.development.js
+++ b/main.development.js
@@ -1,6 +1,6 @@
 import {app, BrowserWindow, Menu, shell} from 'electron';
 import restify from 'restify';
-import SequelizeManager from './sequelizeManager';
+import {SequelizeManager, OPTIONS} from './sequelizeManager';
 import {ipcMessageReceive,
         serverMessageReceive,
         channel} from './messageHandler';
@@ -24,7 +24,7 @@ app.on('window-all-closed', () => {
 app.on('ready', () => {
     mainWindow = new BrowserWindow({
         show: false,
-        width: 1024,
+        width: OPTIONS.large ? 1024 : 728,
         height: 728
     });
 
@@ -46,13 +46,17 @@ app.on('ready', () => {
         origins: ['*'],
         credentials: false,
         headers: ['Access-Control-Allow-Origin']
-    })).listen(5000);
+    })).listen(OPTIONS.port);
 
     mainWindow.loadURL(`file://${__dirname}/app/app.html`);
 
     mainWindow.webContents.on('did-finish-load', () => {
-        mainWindow.show();
-        mainWindow.focus();
+
+        if (!OPTIONS.headless) {
+            mainWindow.show();
+            mainWindow.focus();
+        }
+
         ipcMain.removeAllListeners(channel);
         ipcMain.on(channel, ipcMessageReceive(sequelizeManager));
 

--- a/main.development.js
+++ b/main.development.js
@@ -1,5 +1,6 @@
 import {app, BrowserWindow, Menu, shell} from 'electron';
 import restify from 'restify';
+import bunyan from 'bunyan';
 import {SequelizeManager, OPTIONS} from './sequelizeManager';
 import {ipcMessageReceive,
         serverMessageReceive,
@@ -28,7 +29,18 @@ app.on('ready', () => {
         height: 728
     });
 
+    const logToFile = bunyan.createLogger({
+        name: 'plotly-database-connector-logger',
+        streams: [
+            {
+                level: 'info',
+                path: OPTIONS.logpath
+            }
+        ]
+    });
+
     function log(description) {
+        logToFile.info(description);
         mainWindow.webContents.send(channel, {
                 log: {
                     description,

--- a/messageHandler.js
+++ b/messageHandler.js
@@ -156,7 +156,7 @@ function handleMessage(sequelizeManager, opts) {
 		}
 
 		case TASKS.CHECK_CONNECTION: {
-			sequelizeManager.check_connection(callback)
+			sequelizeManager.checkConnection(callback)
 			.catch( error => {
 				sequelizeManager.raiseError(
 					merge(error, {type: 'connection'}),

--- a/messageHandler.js
+++ b/messageHandler.js
@@ -15,6 +15,10 @@ export function serverMessageReceive(sequelizeManager, mainWindowContents) {
 
 	return (requestEvent, respondEvent) => {
 
+		sequelizeManager.log(
+			`Received a server message to ${requestEvent.route.path}`, 2
+		);
+
 		const payload = {};
 		const {connection} = sequelizeManager;
 		const sequelizeSetup = () => {
@@ -84,7 +88,8 @@ export function serverMessageReceive(sequelizeManager, mainWindowContents) {
 			}
 
 			default: {
-				throw new Error('no task provided to messageHandler');
+				sequelizeManager.log('Error! This route is not implemented', 0);
+				throw new Error('This route is not implemented!');
 			}
 		}
 
@@ -102,6 +107,8 @@ export function serverMessageReceive(sequelizeManager, mainWindowContents) {
 
 export function ipcMessageReceive(sequelizeManager) {
 	return (evt, payload) => {
+
+		sequelizeManager.log(`Received an ipc message to ${payload.task}`, 2);
 
 		const callback = (message) => {
 			evt.sender.send(channel, message);
@@ -122,6 +129,8 @@ function handleMessage(sequelizeManager, opts) {
 	const {callback, payload} = opts;
 	const {task, message} = payload;
 
+	sequelizeManager.log(`Sending task ${task} to squelizeManager`, 2);
+
 	switch (task) {
 		case TASKS.CONNECT: {
 			sequelizeManager.login(message)
@@ -134,7 +143,7 @@ function handleMessage(sequelizeManager, opts) {
 			.then(sequelizeManager.showDatabases(callback))
 			.then(() => {sequelizeManager.log(
 				'NOTE: you are logged in as ' +
-				`[${sequelizeManager.connection.config.username}]`
+				`[${sequelizeManager.connection.config.username}]`, 1
 			);})
 			.catch( error => {
 				sequelizeManager.raiseError(error, callback);
@@ -147,7 +156,7 @@ function handleMessage(sequelizeManager, opts) {
 			.then(sequelizeManager.showTables(callback))
 			.then(() => {sequelizeManager.log(
 				'NOTE: you are previewing database ' +
-				`[${sequelizeManager.connection.config.database}]`
+				`[${sequelizeManager.connection.config.database}]`, 1
 			);})
 			.catch( error => {
 				sequelizeManager.raiseError(error, callback);
@@ -166,7 +175,7 @@ function handleMessage(sequelizeManager, opts) {
 			.then(sequelizeManager.showDatabases(callback))
 			.then(() => {sequelizeManager.log(
 				'NOTE: you are logged in as ' +
-				`[${sequelizeManager.connection.config.username}]`
+				`[${sequelizeManager.connection.config.username}]`, 1
 			);})
 			.catch( error => {
 				sequelizeManager.raiseError(error, callback);
@@ -178,7 +187,7 @@ function handleMessage(sequelizeManager, opts) {
 			const query = message;
 			sequelizeManager.sendQuery(query, callback)
 			.then(() => {sequelizeManager.log(
-				`QUERY EXECUTED: ${query}`
+				`QUERY EXECUTED: ${query}`, 1
 			);})
 			.catch( error => {
 				sequelizeManager.raiseError(error, callback);
@@ -191,7 +200,7 @@ function handleMessage(sequelizeManager, opts) {
 				sequelizeManager.disconnect(callback);
 				sequelizeManager.log(
 					'NOTE: you are logged out as ' +
-					`[${sequelizeManager.connection.config.username}]`
+					`[${sequelizeManager.connection.config.username}]`, 1
 				);
 			} catch (error) {
 				sequelizeManager.raiseError(error, callback);
@@ -200,7 +209,8 @@ function handleMessage(sequelizeManager, opts) {
 		}
 
 		default: {
-			throw new Error('no task provided to messageHandler');
+			sequelizeManager.log('Error! This task is not implemented', 0);
+			throw new Error('Error! This task is not implemented');
 		}
 	}
 }

--- a/messageHandler.js
+++ b/messageHandler.js
@@ -34,7 +34,18 @@ export function serverMessageReceive(sequelizeManager, mainWindowContents) {
 					connection already established and asks for the list
 					of databases. thus the GET_DATABASES instead of CONNECT
 				*/
-				payload.task = TASKS.GET_DATABASES;
+				payload.task = TASKS.CHECK_CONNECTION;
+				/*
+					use connection params as established by the app.
+					no payload required here from remote server to connect
+				*/
+				payload.message = sequelizeSetup();
+				break;
+			}
+
+			case '/login':
+			case '/v0/login': {
+				payload.task = TASKS.CONNECT;
 				/*
 					use connection params as established by the app.
 					no payload required here from remote server to connect
@@ -144,7 +155,7 @@ function handleMessage(sequelizeManager, opts) {
 			break;
 		}
 
-		case TASKS.GET_DATABASES: {
+		case TASKS.CHECK_CONNECTION: {
 			sequelizeManager.check_connection(callback)
 			.catch( error => {
 				sequelizeManager.raiseError(

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
   },
   "dependencies": {
     "brace": "^0.8.0",
+    "bunyan": "^1.8.1",
     "classnames": "^2.2.5",
     "css-modules-require-hook": "^4.0.0",
     "electron-debug": "^0.6.0",

--- a/sequelizeManager.js
+++ b/sequelizeManager.js
@@ -1,15 +1,12 @@
+import * as fs from 'fs';
 import Sequelize from 'sequelize';
 import {DIALECTS} from './app/constants/constants';
 import parse from './parse';
 import {merge} from 'ramda';
 import {ARGS} from './args';
 
-export const OPTIONS = ARGS;
-const CONFIG = require(ARGS.configpath);
-console.log(CONFIG);
-
-const APP_NOT_CONNECTED_MESSAGE = 'There seems to be no connection at the moment.' +
-    ' Please try connecting the application to your database.';
+const APP_NOT_CONNECTED_MESSAGE = 'There seems to be no connection at the ' +
+    'moment. Please try connecting the application to your database.';
 
 const PREBUILT_QUERY = {
     SHOW_DATABASES: 'SHOW_DATABASES',
@@ -78,17 +75,27 @@ export class SequelizeManager {
         return tables;
     }
 
-    login({username, password, database, port, dialect, storage, host}) {
-        if (OPTIONS.headless) {
-            const {username, password, database,
-            port, dialect, storage, host} = CONFIG;
-        }
+    createConnection(configuration) {
+        const {
+            username, password, database, port,
+            dialect, storage, host
+            } = configuration;
+
         this.connection = new Sequelize(database, username, password, {
             dialect,
             host,
             port,
             storage
         });
+    }
+
+    login(configFromApp) {
+        if (ARGS.headless) {
+            const configFromFile = JSON.parse(fs.readFileSync(ARGS.configpath));
+            this.createConnection(configFromFile);
+        } else {
+            this.createConnection(configFromApp);
+        }
 
         if (this.connection.config.dialect === 'mssql') {
             this.connection.config.dialectOptions = {encrypt: true};
@@ -254,3 +261,5 @@ export class SequelizeManager {
         }
     }
 }
+
+export const OPTIONS = ARGS;

--- a/sequelizeManager.js
+++ b/sequelizeManager.js
@@ -104,7 +104,7 @@ export class SequelizeManager {
         return this.connection.authenticate();
     }
 
-    check_connection(callback) {
+    checkConnection(callback) {
         // when already logged in and simply want to check connection
         if (!this.connection) {
 			this.raiseError(

--- a/sequelizeManager.js
+++ b/sequelizeManager.js
@@ -2,6 +2,11 @@ import Sequelize from 'sequelize';
 import {DIALECTS} from './app/constants/constants';
 import parse from './parse';
 import {merge} from 'ramda';
+import {ARGS} from './args';
+
+export const OPTIONS = ARGS;
+const CONFIG = require(ARGS.configpath);
+console.log(CONFIG);
 
 const APP_NOT_CONNECTED_MESSAGE = 'There seems to be no connection at the moment.' +
     ' Please try connecting the application to your database.';
@@ -45,7 +50,7 @@ function assembleTablesPreviewMessage(tablePreviews) {
     });
 }
 
-export default class SequelizeManager {
+export class SequelizeManager {
     constructor(log) {
         this.log = log;
     }
@@ -74,6 +79,10 @@ export default class SequelizeManager {
     }
 
     login({username, password, database, port, dialect, storage, host}) {
+        if (OPTIONS.headless) {
+            const {username, password, database,
+            port, dialect, storage, host} = CONFIG;
+        }
         this.connection = new Sequelize(database, username, password, {
             dialect,
             host,

--- a/test/e2e.js
+++ b/test/e2e.js
@@ -185,6 +185,7 @@ describe('plotly database connector', function Spec() {
         before(openApp);
 
         describe('upon starting', () => {
+
             it('should have the correct app title Name and Version',
             async () => {
                 const title = await this.driver.getTitle();
@@ -358,7 +359,7 @@ describe('plotly database connector', function Spec() {
 
             it('should show a log with a new logged item',
             async () => {
-                const expectedClass = 'test-1-entries';
+                const expectedClass = 'test-4-entries';
                 const logs = await this.getLogs();
 
                 const testClass = await this.getClassOf(logs);
@@ -386,7 +387,7 @@ describe('plotly database connector', function Spec() {
 
             it('should show a log with a new logged item',
             async () => {
-                const expectedClass = 'test-2-entries';
+                const expectedClass = 'test-20-entries';
                 const logs = await this.getLogs();
 
                 const testClass = await this.getClassOf(logs);
@@ -437,7 +438,7 @@ describe('plotly database connector', function Spec() {
 
             it('should show a log with a new logged item',
             async () => {
-                const expectedClass = 'test-3-entries';
+                const expectedClass = 'test-22-entries';
                 const logs = await this.getLogs();
 
                 const testClass = await this.getClassOf(logs);
@@ -471,7 +472,7 @@ describe('plotly database connector', function Spec() {
             const btn = await this.getConnectBtn();
 
             await this.waitFor(expectedClass, btn);
-            
+
             const testClass = await this.getClassOf(btn);
             expect(testClass).to.contain(expectedClass);
         });
@@ -511,7 +512,7 @@ describe('plotly database connector', function Spec() {
 
         it('should show a log with a new logged item',
         async () => {
-            const expectedClass = 'test-1-entries';
+            const expectedClass = 'test-5-entries';
             const logs = await this.getLogs();
 
             const testClass = await this.getClassOf(logs);


### PR DESCRIPTION
adds these possible `args` when running the app from command line
```
    headless: {
        defaultValue: false,
        acceptedValues: [false, true]
    },
    port: {
        defaultValue: 5000,
        acceptedValues: range(1, 10000)
    },
    logpath: {
        defaultValue: './log.txt',
        acceptedValues: 'path to logpath w/o quotes (ex: path/to/log.txt)'
    },
    configpath: {
        defaultValue: './config.json',
        acceptedValues: 'path to config w/o quotes (ex: path/to/config.json)'
    },
    logdetail: {
        defaultValue: 1,
        acceptedValues: range(0, 4)
    }
```

to be used such as 
`npm run start --args headless=true port=5001` when running a build or 
`open -a Plotly\ Database\ Connector.app --args headless=true port=5001` when running a packaged app file