### PR TITLE
[ISSUE] Resolves error trying rendering the dropdown options when tables array is empty

### DIFF
--- a/app/components/Settings/TableDropdown/TableDropdown.react.js
+++ b/app/components/Settings/TableDropdown/TableDropdown.react.js
@@ -51,6 +51,14 @@ export default class TableDropdown extends Component {
 
         if (tableNames === null) {
             tablesDropdownOptions = [
+                {
+                    value: 'Please Select a Database',
+                    label: 'Please Select a Database',
+                    disabled: true
+                }
+            ];
+        } else if (tableNames.length === 0) {
+            tablesDropdownOptions = [
                 {value: 'None', label: 'None Found', disabled: true}
             ];
         } else {


### PR DESCRIPTION
resolves #80 
added a check for length of tables' array.
displays 'select a database' if null, dispplays 'none' if tables received and array is empty
![](http://g.recordit.co/wgvVBRrF4Y.gif)