### PR TITLE
Add database options ui

### DIFF
--- a/app/components/Settings/ConnectButton/ConnectButton.css
+++ b/app/components/Settings/ConnectButton/ConnectButton.css
@@ -18,6 +18,10 @@
     margin-right:auto;
 }
 
+.buttonPrimary:hover {
+    border-color: #8BB5FE
+}
+
 .errorMessage {
     color: red;
     overflow-x: scroll;

--- a/app/components/Settings/UserCredentials/UserCredentials.css
+++ b/app/components/Settings/UserCredentials/UserCredentials.css
@@ -21,9 +21,40 @@ input {
     text-align: left;
     height: 40px;
     margin-top: 9px;
-    /* width: 300px; */
 }
 
-input:hover, input:focus {
+
+input:hover {
     border-bottom-color: #8BB5FE;
+}
+
+.checkbox {
+    margin-top: 1px;
+    display: inline;
+    vertical-align: middle;
+    width: 30px;
+}
+
+.label {
+    font: 16px BlinkMacSystemFont;
+}
+
+.options:hover {
+
+}
+
+.databaseOptionsContainer {
+    text-align: left;
+    padding-left: 150px;
+    padding-top: 25px;
+}
+
+.databaseOptions {
+    color: #6D6D6D;
+    font-weight: 100;
+    font-size: 18px;
+}
+
+.databaseOptions:hover {
+    color: #8BB5FE;
 }

--- a/app/components/Settings/UserCredentials/UserCredentials.react.js
+++ b/app/components/Settings/UserCredentials/UserCredentials.react.js
@@ -16,6 +16,7 @@ export default class UserCredentials extends Component {
 		this.getInputType = this.getInputType.bind(this);
 		this.getOnClick = this.getOnClick.bind(this);
 		this.testClass = this.testClass.bind(this);
+        this.state = {showOptions: false};
     }
 
 	testClass() {
@@ -81,9 +82,54 @@ export default class UserCredentials extends Component {
 			/>
 		));
 
+        let options = CONNETION_OPTIONS[configuration.get('dialect')]
+            .map(credential => (
+            <div className={styles.options}>
+                <label className={styles.label}><input
+                    className={styles.checkbox}
+                    type="checkbox"
+                    onChange={() => {
+                        sessionsActions.updateConfiguration(
+                            {[credential]: !configuration.get(credential)}
+                        );
+                    }}
+                    id={`test-option-${credential}`}
+                />
+                {credential}
+                </label>
+            </div>
+        ));
+
+        const databaseOptions = () => {
+            if (this.state.showOptions) {
+                return (
+                    <div className={styles.databaseOptionsContainer}>
+                        <a className={styles.databaseOptions}
+                            onClick={() => {this.setState({showOptions: false});}}
+                        >
+                            Hide Database Options
+                        </a>
+                        {options}
+                    </div>
+                );
+            } else {
+                return (
+                    <div className={styles.databaseOptionsContainer}>
+                        <a className={styles.databaseOptions}
+                            onClick={() => {this.setState({showOptions: true});}}
+                        >
+                            Show Database Options
+                        </a>
+                    </div>
+                );
+            }
+        };
+
+
 		return (
 			<div className={styles.inputContainer}>
 				{inputs}
+                {databaseOptions()}
 			</div>
 		);
 	}

--- a/app/components/Settings/UserCredentials/UserCredentials.react.js
+++ b/app/components/Settings/UserCredentials/UserCredentials.react.js
@@ -1,7 +1,9 @@
 import React, {Component, PropTypes} from 'react';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import * as styles from './UserCredentials.css';
-import {USER_INPUT_FIELDS} from '../../../constants/constants';
+import {
+    CONNETION_CONFIG, CONNETION_OPTIONS
+} from '../../../constants/constants';
 const {dialog} = require('electron').remote;
 
 /*
@@ -68,7 +70,7 @@ export default class UserCredentials extends Component {
 	render() {
 		const {configuration, sessionsActions} = this.props;
 
-		let inputs = USER_INPUT_FIELDS[configuration.get('dialect')]
+		let inputs = CONNETION_CONFIG[configuration.get('dialect')]
 			.map(credential => (
 			<input className={this.testClass()}
 				placeholder={this.getPlaceholder(credential)}

--- a/app/constants/constants.js
+++ b/app/constants/constants.js
@@ -21,7 +21,7 @@ export const APP_STATUS = {
     DISCONNECTED: 'DISCONNECTED'
 };
 
-export const USER_INPUT_FIELDS = {
+export const CONNETION_CONFIG = {
     [DIALECTS.MYSQL]: ['username', 'password', 'host', 'port'],
     [DIALECTS.MARIADB]: ['username', 'password', 'host', 'port'],
 	[DIALECTS.MSSQL]: ['username', 'password', 'host', 'port'],

--- a/app/constants/constants.js
+++ b/app/constants/constants.js
@@ -30,6 +30,15 @@ export const USER_INPUT_FIELDS = {
     [DIALECTS.SQLITE]: ['storage']
 };
 
+export const CONNETION_OPTIONS = {
+    [DIALECTS.MYSQL]: ['ssl'],
+    [DIALECTS.MARIADB]: ['ssl'],
+	[DIALECTS.MSSQL]: ['ssl'],
+    [DIALECTS.POSTGRES]: ['ssl'],
+    [DIALECTS.REDSHIFT]: ['ssl'],
+    [DIALECTS.SQLITE]: ['storage']
+};
+
 export const BUTTON_MESSAGE = {
     INITIALIZED: 'connect',
     CON_ERROR: 'try again',
@@ -48,7 +57,8 @@ export const EMPTY_SESSION =
         dialect: DIALECTS.MYSQL,
         port: '',
         storage: '',
-        host: ''
+        host: '',
+        ssl: false
     },
     CONNECTION: {status: APP_STATUS.INITIALIZED}
 };

--- a/backend/sequelizeManager.js
+++ b/backend/sequelizeManager.js
@@ -19,7 +19,10 @@ const REDSHIFT_OPTIONS = {
     dialect: 'postgres',
     pool: false,
     keepDefaultTimezone: true, // avoid SET TIMEZONE
-    databaseVersion: '8.0.2' // avoid SHOW SERVER_VERSION
+    databaseVersion: '8.0.2', // avoid SHOW SERVER_VERSION
+    dialectOptions: {
+        ssl: true
+    }
 };
 
 const setupMSSQLOptions = (connection) => {
@@ -119,10 +122,13 @@ export class SequelizeManager {
 
     createConnection(configuration) {
         const {
-            username, password, database, port, dialect, storage, host
+            username, password, database, port, dialect, storage, host, ssl
             } = configuration;
 
-        let options = {dialect, host, port, storage};
+        let options = {
+            dialect, host, port, storage,
+            dialectOptions: {ssl}
+        };
 
         this.log(`Creating a connection for user ${username}`, 1);
 

--- a/test/e2e.js
+++ b/test/e2e.js
@@ -10,7 +10,7 @@ import {productName, version} from '../package.json';
 import {
     APP_STATUS,
     DIALECTS,
-    USER_INPUT_FIELDS
+    CONNETION_CONFIG
 } from '../app/constants/constants';
 
 // import styles to use for tests
@@ -168,7 +168,7 @@ describe('plotly database connector', function Spec() {
 
         // user inputs
         this.fillInputs = async (testedDialect) => {
-            USER_INPUT_FIELDS[testedDialect].forEach(credential => {
+            CONNETION_CONFIG[testedDialect].forEach(credential => {
                 this.getInputField(credential)
                 .then(input => {
                     input.sendKeys(CREDENTIALS[testedDialect][credential]);
@@ -177,7 +177,7 @@ describe('plotly database connector', function Spec() {
         };
 
         this.wrongInputs = async (testedDialect) => {
-            USER_INPUT_FIELDS[testedDialect].forEach(credential => {
+            CONNETION_CONFIG[testedDialect].forEach(credential => {
                 this.getInputField(credential)
                 .then(input => input.sendKeys('blah'));
             });


### PR DESCRIPTION
adds the option `ssl` to the UI as a database option
as in if ssl is used by the remote database (certificates have been setup)
can remain undefined for most databases except redshift

- from now on, it's defaulted to `false` and can be overwritten by the user using the checkbox
- for reshift it's defaulted to true always

![](http://g.recordit.co/Ba1yc4CrYn.gif)