### PR TITLE
Remove documentation setting

### DIFF
--- a/app/components/Settings/UserConnections/UserConnections.react.js
+++ b/app/components/Settings/UserConnections/UserConnections.react.js
@@ -156,17 +156,9 @@ export default class UserConnections extends Component {
             <div className={styles.inputContainer}>
 
                     <div className={styles.inputNamesContainer}>
-                        <span className ={styles.inputName}>{'Documentation'}</span>
                         {inputNames}
                     </div>
                     <div className={styles.inputFieldsContainer}>
-                        <a className={styles.documentationLink}
-                            onClick={() => {
-                            shell.openExternal(documentationLink(connectionObject.dialect));
-                        }}
-                        >
-                            plotly &nbsp;{connectionObject.dialect}&nbsp; documentation
-                        </a>
                         {inputs}
                         <div className={styles.optionsContainer}>
                             {options}


### PR DESCRIPTION
![](https://cloud.githubusercontent.com/assets/1280389/21213812/f7316f3a-c264-11e6-8122-8e01fa09adbf.gif)

Clicking on the documentation is broken on the web build right now. Also, I don't think that we even have valid links for all of the dialects any more (elasticsearch, s3, apache drill)