### PR TITLE
Accept credentials header serverside

### DIFF
--- a/backend/routes.js
+++ b/backend/routes.js
@@ -99,7 +99,7 @@ export default class Server {
         ];
         server.use(restify.CORS({
             origins: getSetting('CORS_ALLOWED_ORIGINS'),
-            credentials: false,
+            credentials: true,
             headers: headers
         }));
         headers.forEach(header => restify.CORS.ALLOW_HEADERS.push(header));


### PR DESCRIPTION
After including credentials in the streambed client side requests to connector's server:

> Fetch API cannot load https://plotly-connector.herokuapp.com/connections. Response to preflight request doesn't pass access control check: The value of the 'Access-Control-Allow-Credentials' header in the response is '' which must be 'true' when the request's credentials mode is 'include'. Origin 'https://local.plot.ly' is therefore not allowed access.